### PR TITLE
Update clang-format-all

### DIFF
--- a/scripts/clang-format-all
+++ b/scripts/clang-format-all
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # clang-format-all: a tool to run clang-format on an entire project
+#
 # Copyright (C) 2016 Evan Klitzke <evan@eklitzke.org>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,69 +17,119 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-function usage {
-    echo "Usage: $0 DIR..."
+################################################################################
+# Print usage instructions and exit
+################################################################################
+usage() {
+    cat <<EOF
+Usage:
+  $0 DIR...
+
+Runs clang-format on all valid source code files found under the specified
+directories. Must pass at least one directory.
+
+Examples:
+  $0 .
+  $0 src include tests
+EOF
     exit 1
 }
 
-if [ $# -eq 0 ]; then
-    usage
-fi
+################################################################################
+# Try to find an installed clang-format command (preferring unversioned if available)
+################################################################################
+find_clang_format() {
+    local clangfmt
 
-# Variable that will hold the name of the clang-format command
-FMT=""
+    # Attempt standard 'clang-format' first, then fallback to versioned commands
+    for clangfmt in clang-format \
+                    clang-format-15 clang-format-14 clang-format-13 clang-format-12 \
+                    clang-format-11 clang-format-10 clang-format-9 clang-format-8 \
+                    clang-format-7  clang-format-6  clang-format-5 clang-format-4 \
+                    clang-format-3  clang-format-3.9 clang-format-3.8 \
+                    clang-format-3.7 clang-format-3.6 clang-format-3.5 \
+                    clang-format-3.4 clang-format-3.3 clang-format-3.2 \
+                    clang-format-3.1 clang-format-3.0; do
+        if command -v "${clangfmt}" &>/dev/null; then
+            echo "${clangfmt}"
+            return 0
+        fi
+    done
+    return 1
+}
 
-# Some distros just call it clang-format. Others (e.g. Ubuntu) are insistent
-# that the version number be part of the command. We prefer clang-format if
-# that's present, otherwise we work backwards from highest version to lowest
-# version.
-for clangfmt in clang-format{,-{4,3}.{9,8,7,6,5,4,3,2,1,0}}; do
-    if which "$clangfmt" &>/dev/null; then
-        FMT="$clangfmt"
-        break
-    fi
-done
+################################################################################
+# Recursively look upward for a .clang-format from a given directory
+################################################################################
+find_dominating_file() {
+    local start_dir="$1"
+    local target_file="$2"
 
-# Check if we found a working clang-format
-if [ -z "$FMT" ]; then
-    echo "failed to find clang-format"
-    exit 1
-fi
-
-# Check all of the arguments first to make sure they're all directories
-for dir in "$@"; do
-    if [ ! -d "${dir}" ]; then
-        echo "${dir} is not a directory"
-        usage
-    fi
-done
-
-# Find a dominating file, starting from a given directory and going up.
-find-dominating-file() {
-    if [ -r "$1"/"$2" ]; then
+    # If the file exists in this directory, done
+    if [[ -r "$start_dir/$target_file" ]]; then
         return 0
     fi
-    if [ "$1" = "/" ]; then
+
+    # If we've reached root without finding it, fail
+    if [[ "$start_dir" == "/" ]]; then
         return 1
     fi
-    find-dominating-file "$(realpath "$1"/..)" "$2"
+
+    # Recurse upward
+    find_dominating_file "$(realpath "$start_dir/..")" "$target_file"
     return $?
 }
 
-# Run clang-format -i on all of the things
-for dir in "$@"; do
-    pushd "${dir}" &>/dev/null
-    if ! find-dominating-file . .clang-format; then
-        echo "Failed to find dominating .clang-format starting at $PWD"
-        continue
+################################################################################
+# Main script logic
+################################################################################
+main() {
+    # At least one directory must be passed
+    if [[ $# -eq 0 ]]; then
+        usage
     fi
-    find . \
-         \( -name '*.c' \
-         -o -name '*.cc' \
-         -o -name '*.cpp' \
-         -o -name '*.h' \
-         -o -name '*.hh' \
-         -o -name '*.hpp' \) \
-         -exec "${FMT}" -i '{}' \;
-    popd &>/dev/null
-done
+
+    # Check that all arguments are valid directories
+    for dir in "$@"; do
+        if [[ ! -d "$dir" ]]; then
+            echo "Error: '$dir' is not a directory."
+            usage
+        fi
+    done
+
+    # Attempt to find a working clang-format
+    local FMT=""
+    FMT="$(find_clang_format)"
+    if [[ -z "$FMT" ]]; then
+        echo "Error: Failed to find any 'clang-format' installation."
+        exit 1
+    fi
+
+    echo "Using clang-format command: $FMT"
+
+    # For each directory argument, find a dominating .clang-format and run clang-format
+    for dir in "$@"; do
+        pushd "$dir" &>/dev/null || {
+            echo "Warning: Failed to enter directory '$dir'; skipping."
+            continue
+        }
+
+        # Confirm there's a .clang-format in an upper directory
+        if ! find_dominating_file "." ".clang-format"; then
+            echo "Warning: No .clang-format found up the tree from $PWD. Skipping."
+            popd &>/dev/null
+            continue
+        fi
+
+        # Format all recognized source code files in place
+        echo "Running clang-format in $(pwd)..."
+        find . \
+             \( -name '*.c'   -o -name '*.cc'   -o -name '*.cpp' \
+             -o  -name '*.h'  -o -name '*.hh'   -o -name '*.hpp' \) \
+             -exec "${FMT}" -i '{}' \;
+
+        popd &>/dev/null
+    done
+}
+
+main "$@"


### PR DESCRIPTION
Below is a refactored version of the clang-format-all Bash script. It provides:

Clearer structure, with separate functions for tasks like usage, checking dependencies, finding the .clang-format file, etc. Consistent and safe shell scripting best practices, including quoting variables, using local in functions, and checking command outcomes. Detailed commentary describing each section’s logic and any potential edge cases. Feel free to tailor the script further to your needs or environment.

bash
Copy code
#!/usr/bin/env bash
#
# clang-format-all: a tool to run clang-format on an entire project #
# Copyright (C) 2016 Evan Klitzke <evan@eklitzke.org> #
# This program is free software: you can redistribute it and/or modify # it under the terms of the GNU General Public License as published by # the Free Software Foundation, either version 3 of the License, or # (at your option) any later version.
#
# This program is distributed in the hope that it will be useful, # but WITHOUT ANY WARRANTY; without even the implied warranty of # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the # GNU General Public License for more details.
#
# You should have received a copy of the GNU General Public License # along with this program.  If not, see <http://www.gnu.org/licenses/>.

################################################################################ # Print usage instructions and exit
################################################################################ usage() {
    cat <<EOF
Usage:
  $0 DIR...

Runs clang-format on all valid source code files found under the specified directories. Must pass at least one directory.

Examples:
  $0 .
  $0 src include tests
EOF
    exit 1
}

################################################################################ # Try to find an installed clang-format command (preferring unversioned if available) ################################################################################ find_clang_format() {
    local clangfmt

    # Attempt standard 'clang-format' first, then fallback to versioned commands
    for clangfmt in clang-format \
                    clang-format-15 clang-format-14 clang-format-13 clang-format-12 \
                    clang-format-11 clang-format-10 clang-format-9 clang-format-8 \
                    clang-format-7  clang-format-6  clang-format-5 clang-format-4 \
                    clang-format-3  clang-format-3.9 clang-format-3.8 \
                    clang-format-3.7 clang-format-3.6 clang-format-3.5 \
                    clang-format-3.4 clang-format-3.3 clang-format-3.2 \
                    clang-format-3.1 clang-format-3.0; do
        if command -v "${clangfmt}" &>/dev/null; then
            echo "${clangfmt}"
            return 0
        fi
    done
    return 1
}

################################################################################ # Recursively look upward for a .clang-format from a given directory ################################################################################ find_dominating_file() {
    local start_dir="$1"
    local target_file="$2"

    # If the file exists in this directory, done
    if [[ -r "$start_dir/$target_file" ]]; then
        return 0
    fi

    # If we've reached root without finding it, fail
    if [[ "$start_dir" == "/" ]]; then
        return 1
    fi

    # Recurse upward
    find_dominating_file "$(realpath "$start_dir/..")" "$target_file"
    return $?
}

################################################################################ # Main script logic
################################################################################ main() {
    # At least one directory must be passed
    if [[ $# -eq 0 ]]; then
        usage
    fi

    # Check that all arguments are valid directories
    for dir in "$@"; do
        if [[ ! -d "$dir" ]]; then
            echo "Error: '$dir' is not a directory."
            usage
        fi
    done

    # Attempt to find a working clang-format
    local FMT=""
    FMT="$(find_clang_format)"
    if [[ -z "$FMT" ]]; then
        echo "Error: Failed to find any 'clang-format' installation."
        exit 1
    fi

    echo "Using clang-format command: $FMT"

    # For each directory argument, find a dominating .clang-format and run clang-format
    for dir in "$@"; do
        pushd "$dir" &>/dev/null || {
            echo "Warning: Failed to enter directory '$dir'; skipping."
            continue
        }

        # Confirm there's a .clang-format in an upper directory
        if ! find_dominating_file "." ".clang-format"; then
            echo "Warning: No .clang-format found up the tree from $PWD. Skipping."
            popd &>/dev/null
            continue
        fi

        # Format all recognized source code files in place
        echo "Running clang-format in $(pwd)..."
        find . \
             \( -name '*.c'   -o -name '*.cc'   -o -name '*.cpp' \
             -o  -name '*.h'  -o -name '*.hh'   -o -name '*.hpp' \) \
             -exec "${FMT}" -i '{}' \;

        popd &>/dev/null
    done
}

main "$@"
Highlights & Improvements
Helper Functions

usage(): prints usage instructions, including examples. find_clang_format(): tries a range of potential clang-format commands (including various versioned ones), returning the first that’s found in PATH. find_dominating_file(): recursively checks parent directories for a .clang-format file, so you only format code if the style file is discovered. Safe Shell Scripting

Uses [[ ... ]] for test conditions, ensuring better bash compliance and clarity. Quoting variables to protect against paths with spaces or special characters. command -v ... is used to detect if a command is installed. Graceful fallback if a command fails or a directory push is not possible. Comments & Error Messages

More descriptive error logs (echo "Warning: ...") for each step that can fail or might be optional. Simplicity

Single main() function orchestrates the logic, ensuring the script’s entry point is easy to follow. Passes $@ from the script’s arguments to main, preserving normal usage patterns. Reusability

You could easily copy and adapt the helper functions for other tasks in your build scripts. With these changes, the script should be more robust and maintainable. Remember to give the file executable permissions via chmod +x clang-format-all (or rename it as you wish) before usage.